### PR TITLE
Create a shadow ZTP data json file accessible to non-root user

### DIFF
--- a/src/usr/bin/ztp
+++ b/src/usr/bin/ztp
@@ -119,6 +119,10 @@ def getActivityString():
        print ('ZTP Service is not running\n')
        return
 
+    if os.geteuid() != 0:
+       print ('ZTP Service is active\n')
+       return
+
     activity_str = None
     f = getCfg('ztp-activity')
     if os.path.isfile(f):
@@ -160,6 +164,8 @@ def ztp_erase(yesFlag):
     # Destroy current provisioning data
     if os.path.isfile(getCfg('ztp-json', ztp_cfg=ztp_cfg)):
         os.remove(getCfg('ztp-json', ztp_cfg=ztp_cfg))
+    if os.path.isfile(getCfg('ztp-json-shadow', ztp_cfg=ztp_cfg)):
+        os.remove(getCfg('ztp-json-shadow', ztp_cfg=ztp_cfg))
 
 ## Administratively disable ZTP.
 #  It also stops ztp service if it found active, before modifying the configuration.
@@ -219,8 +225,8 @@ def ztp_run(yesFlag):
 def ztp_status_code():
     if getCfg('admin-mode', ztp_cfg=ztp_cfg) is False:
         print ('0:DISABLED')
-    elif os.path.isfile(getCfg('ztp-json', ztp_cfg=ztp_cfg)):
-        objJson, jsonDict = JsonReader(getCfg('ztp-json', ztp_cfg=ztp_cfg), indent=4)
+    elif os.path.isfile(getCfg('ztp-json-shadow', ztp_cfg=ztp_cfg)):
+        objJson, jsonDict = JsonReader(getCfg('ztp-json-shadow', ztp_cfg=ztp_cfg), indent=4)
         ztpDict = jsonDict.get('ztp')
         if ztpDict.get('status') == 'BOOT':
             print ('3:NOT-STARTED')
@@ -241,8 +247,8 @@ def ztp_status_code():
 def ztp_status_terse():
     # Print overall ZTP status
     print ('ZTP Admin Mode : %r' % getCfg('admin-mode', ztp_cfg=ztp_cfg))
-    if os.path.isfile(getCfg('ztp-json', ztp_cfg=ztp_cfg)):
-        objJson, jsonDict = JsonReader(getCfg('ztp-json', ztp_cfg=ztp_cfg), indent=4)
+    if os.path.isfile(getCfg('ztp-json-shadow', ztp_cfg=ztp_cfg)):
+        objJson, jsonDict = JsonReader(getCfg('ztp-json-shadow', ztp_cfg=ztp_cfg), indent=4)
         ztpDict = jsonDict.get('ztp')
         if ztp_active() != 0:
             print ('ZTP Service    : Inactive')
@@ -284,8 +290,8 @@ def ztp_status():
     print('%s' % 'ZTP')
     print('========================================')
     print ('ZTP Admin Mode : %r' % getCfg('admin-mode', ztp_cfg=ztp_cfg))
-    if os.path.isfile(getCfg('ztp-json', ztp_cfg=ztp_cfg)):
-        objJson, jsonDict = JsonReader(getCfg('ztp-json', ztp_cfg=ztp_cfg), indent=4)
+    if os.path.isfile(getCfg('ztp-json-shadow', ztp_cfg=ztp_cfg)):
+        objJson, jsonDict = JsonReader(getCfg('ztp-json-shadow', ztp_cfg=ztp_cfg), indent=4)
         ztpDict = jsonDict.get('ztp')
         if ztp_active() != 0:
             print ('ZTP Service    : Inactive')
@@ -343,9 +349,11 @@ def ztp_status():
 
 def main():
 
-    # Only privileged users can execute this command
+    # Check the user's root privileges
     if os.geteuid() != 0:
-        sys.exit("Root privileges required for this operation")
+        root_user = False
+    else:
+        root_user = True
 
     # Add allowed arguments
     parser = argparse.ArgumentParser(description="Zero Touch Provisioning configuration and status monitoring tool",
@@ -392,6 +400,9 @@ run      Restart ZTP\nstatus   Display current state of ZTP and last known resul
             print('Exception [%s] occured while reading ZTP configuration file \'%s\'.' % (str(e), cfg_json))
             print('Exiting ZTP service.')
             sys.exit(1)
+
+    if root_user == False and cmd in ['enable', 'disable', 'run', 'erase']:
+        sys.exit("Root privileges required for this operation")
 
     # Execute the command
     try:

--- a/src/usr/lib/python3/dist-packages/ztp/defaults.py
+++ b/src/usr/lib/python3/dist-packages/ztp/defaults.py
@@ -62,6 +62,7 @@ defaultCfg = dict( \
   "ztp-activity"         : '/var/run/ztp/activity', \
   "ztp-cfg-dir"          : "/host/ztp", \
   "ztp-json"             : "/host/ztp/ztp_data.json", \
+  "ztp-json-shadow"      : "/host/ztp/ztp_data_shadow.json", \
   "ztp-json-local"       : "/host/ztp/ztp_data_local.json", \
   "ztp-json-opt59"       : "/var/run/ztp/ztp_data_opt59.json", \
   "ztp-json-opt67"       : "/var/run/ztp/ztp_data_opt67.json", \

--- a/src/usr/lib/ztp/ztp-engine.py
+++ b/src/usr/lib/ztp/ztp-engine.py
@@ -480,6 +480,8 @@ class ZTPEngine():
             logger.error('ZTP JSON file %s processing failed.' % (self.json_src))
             try:
                 os.remove(getCfg('ztp-json'))
+                if os.path.isfile(getCfg('ztp-json-shadow')):
+                    os.remove(getCfg('ztp-json-shadow'))
             except OSError as v:
                 if v.errno != errno.ENOENT:
                     logger.warning('Exception [%s] encountered while deleting ZTP JSON file %s.' % (str(v), getCfg('ztp-json')))
@@ -507,6 +509,8 @@ class ZTPEngine():
                 # Discover new ZTP data after deleting historic ZTP data
                 logger.info("ZTP restart requested. Deleting previous ZTP session JSON data.")
                 os.remove(getCfg('ztp-json'))
+                if os.path.isfile(getCfg('ztp-json-shadow')):
+                    os.remove(getCfg('ztp-json-shadow'))
                 self.objztpJson = None
                 return ("retry", "ZTP restart requested")
             else:
@@ -539,6 +543,8 @@ class ZTPEngine():
         # Mark ZTP for restart
         if _restart_ztp_missing_config or _restart_ztp_on_failure:
             os.remove(getCfg('ztp-json'))
+            if os.path.isfile(getCfg('ztp-json-shadow')):
+               os.remove(getCfg('ztp-json-shadow'))
             self.objztpJson = None
             # Remove startup-config file to obtain a new one through ZTP
             if getCfg('monitor-startup-config') is True and os.path.isfile(getCfg('config-db-json')):

--- a/tests/test_ztp_engine.py
+++ b/tests/test_ztp_engine.py
@@ -129,7 +129,7 @@ class TestClass(object):
         runCommand("systemctl stop ztp")
         # Destroy current provisioning data
         file_list = ["ztp-json-local", "ztp-json-opt67", "ztp-json", "provisioning-script", "opt67-url", "opt59-v6-url", \
-                     "opt239-url", "opt239-v6-url", "ztp-restart-flag", "opt66-tftp-server", "acl-url", "graph-url"]
+                     "opt239-url", "opt239-v6-url", "ztp-restart-flag", "opt66-tftp-server", "acl-url", "graph-url", "ztp-json-shadow"]
 
         for filename in file_list:
             if os.path.isfile(self.cfgGet(filename)):


### PR DESCRIPTION
To allow non-root user to view status information, a shadow file for the current
ztp_data.json is created. The shadow file (ztp_data_shadow.json) contains only
status information which does not provide knowledge of url's of the
configuration scripts used for ztp. The ztp_data_shadow.json file is updated
everytume ztp_data.json is updated. The ztp_data_shadow.json is accessible to
non-root user as well while ztp_data.json is accessible only to root user and
has more information about the url's where configuration scripts can be downloaded
from.

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>