### PR TITLE
Filter out non-printable characters read from syseeprom

### DIFF
--- a/src/usr/lib/python3/dist-packages/ztp/DecodeSysEeprom.py
+++ b/src/usr/lib/python3/dist-packages/ztp/DecodeSysEeprom.py
@@ -18,7 +18,7 @@ limitations under the License.
 import sys
 import os
 
-from ztp.ZTPLib import runCommand
+from ztp.ZTPLib import runCommand, printable
 
 class DecodeSysEeprom:
 
@@ -64,7 +64,7 @@ class DecodeSysEeprom:
         if not rc == 0 or len(cmd_stdout) != 1:
             return 'N.A'
         else:
-            return cmd_stdout[0].rstrip()
+            return printable(cmd_stdout[0].rstrip())
 
 ## Global instance of the class
 sysEeprom = DecodeSysEeprom()

--- a/src/usr/lib/python3/dist-packages/ztp/ZTPLib.py
+++ b/src/usr/lib/python3/dist-packages/ztp/ZTPLib.py
@@ -19,6 +19,7 @@ import datetime
 import time
 import shlex
 import subprocess
+from curses.ascii import isprint
 import ztp.ZTPCfg
 import os.path
 from   ztp.defaults import *
@@ -272,3 +273,17 @@ def systemReboot():
         os.system('reboot -y')
     else:
         os.system('reboot')
+
+def printable(input):
+    '''!
+         Filter out non-printable characters from an input string
+
+         @param input (str) Input string
+
+         @return String with non-printable characters removed
+                 None if invalid input data type
+    '''
+    if input is not None and isString(input):
+        return ''.join(char for char in input if isprint(char))
+    else:
+        return None

--- a/src/usr/lib/ztp/ztp-profile.sh
+++ b/src/usr/lib/ztp/ztp-profile.sh
@@ -117,8 +117,8 @@ ztp_config_create()
         DEST=${TMP_ZTP_CONFIG_DB_JSON}
     fi
 
-    PRODUCT_NAME=$(decode-syseeprom  -p)
-    SERIAL_NO=$(decode-syseeprom  -s)
+    PRODUCT_NAME=$(decode-syseeprom  -p | tr -dc '[[:print:]]')
+    SERIAL_NO=$(decode-syseeprom  -s | tr -dc '[[:print:]]')
     sonic-cfggen -H -k ${HW_KEY} -a "{\"ZTP_INBAND\": \"$(get_feature inband)\", \
              \"ZTP_IPV4\": \"$(get_feature ipv4)\", \"ZTP_IPV6\": \"$(get_feature ipv6)\", \
              \"PRODUCT_NAME\": \"${PRODUCT_NAME}\",  \"SERIAL_NO\": \"${SERIAL_NO}\"}" \

--- a/tests/test_ZTPLib.py
+++ b/tests/test_ZTPLib.py
@@ -21,7 +21,7 @@ import os
 import stat
 import pytest
 
-from ztp.ZTPLib import runCommand, getField, getCfg
+from ztp.ZTPLib import runCommand, getField, getCfg, printable
 sys.path.append(getCfg('plugins-dir'))
 
 class TestClass(object):
@@ -114,3 +114,11 @@ class TestClass(object):
 
         data = dict({'key': {'subkey':10} })
         assert (getField(data, 'key', dict, None).get('subkey') == 10)
+
+    def test_misc(self):
+        assert(printable("Test-/\=$!()*#!_?><,.][{}+String1234567890") == "Test-/\=$!()*#!_?><,.][{}+String1234567890")
+        assert(printable("Te\u20ACst\u20AC") == "Test")
+        assert(printable("\u20AC\u20AC") == "")
+        assert(printable(None) == None)
+        assert(printable({"k": "v"}) == None)
+        assert(printable("") == "")


### PR DESCRIPTION

Added defensive code to check for printable characters in the output of decode-syseeprom command.

Fixes https://github.com/Azure/sonic-ztp/issues/15

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>