### PR TITLE
Update paths to reflect new sonic-utilities install location, /usr/local/bin/

### DIFF
--- a/src/usr/lib/ztp/plugins/configdb-json
+++ b/src/usr/lib/ztp/plugins/configdb-json
@@ -137,7 +137,7 @@ class ConfigDBJson:
             raise Exception(e)
 
         # Run config command
-        cmd = '/usr/bin/config '
+        cmd = 'config '
         if self.__clear_config:
             # Stop ZTP DHCP as it might interfere with config reload
             self.__stop_dhcp()

--- a/src/usr/lib/ztp/plugins/firmware
+++ b/src/usr/lib/ztp/plugins/firmware
@@ -49,7 +49,7 @@ class Firmware:
 
     ## Return the current SONiC image
     def __which_current_image(self):
-        (rc, cmd_stdout, cmd_stderr) = runCommand('/usr/bin/sonic-installer list')
+        (rc, cmd_stdout, cmd_stderr) = runCommand('sonic-installer list')
         if rc != 0:
             return ''
         for l in cmd_stdout:
@@ -59,7 +59,7 @@ class Firmware:
 
     ## Return the next image which will be used at next boot
     def __which_next_image(self):
-        (rc, cmd_stdout, cmd_stderr) = runCommand('/usr/bin/sonic-installer list')
+        (rc, cmd_stdout, cmd_stderr) = runCommand('sonic-installer list')
         if rc != 0:
             return ''
         for l in cmd_stdout:
@@ -69,14 +69,14 @@ class Firmware:
 
     ## Retrieve the binary version for a given image file
     def __binary_version(self, fname):
-        (rc, cmd_stdout, cmd_stderr) = runCommand('/usr/bin/sonic-installer binary-version %s' % (fname))
+        (rc, cmd_stdout, cmd_stderr) = runCommand('sonic-installer binary-version %s' % (fname))
         if rc != 0 or len(cmd_stdout) != 1:
             return ''
         return cmd_stdout[0]
 
     ## Return a list of available images (installed)
     def __available_images(self):
-        (rc, cmd_stdout, cmd_stderr) = runCommand('/usr/bin/sonic-installer list')
+        (rc, cmd_stdout, cmd_stderr) = runCommand('sonic-installer list')
         if rc != 0:
             return ''
         index = 0;
@@ -92,7 +92,7 @@ class Firmware:
 
         @param image (str) SONiC image filename
         '''
-        cmd = '/usr/bin/sonic-installer set-default ' + image
+        cmd = 'sonic-installer set-default ' + image
         rc = runCommand(cmd, capture_stdout=False)
         if rc != 0:
             self.__bailout('Error (%d) on command \'%s\'' %(rc, cmd))
@@ -103,7 +103,7 @@ class Firmware:
 
         @param image (str) SONiC image filename
         '''
-        cmd = '/usr/bin/sonic-installer set-next-boot %s' % (image)
+        cmd = 'sonic-installer set-next-boot %s' % (image)
         rc = runCommand(cmd, capture_stdout=False)
         if rc != 0:
             self.__bailout('Error (%d) on command \'%s\'' %(rc, cmd))
@@ -229,7 +229,7 @@ class Firmware:
         available_images_before = self.__available_images()
 
         # Create command
-        cmd = '/usr/bin/sonic-installer remove -y ' + image_name
+        cmd = 'sonic-installer remove -y ' + image_name
 
         # Execute sonic-installer command
         try:
@@ -374,7 +374,7 @@ class Firmware:
                 return
 
         # Create command
-        cmd = '/usr/bin/sonic-installer install -y ' + self.__dest_file
+        cmd = 'sonic-installer install -y ' + self.__dest_file
 
         # Execute sonic-installer command
         logger.info('firmware: Installing firmware image located at \'%s\'.' % self.__dest_file)
@@ -458,7 +458,7 @@ class Firmware:
 
         # Create command
         logger.info('firmware: Upgrading container %s using docker image file %s.' % (self.__container_name, self.__dest_file))
-        cmd = '/usr/bin/sonic-installer upgrade-docker -y %s %s' % (self.__container_name, self.__dest_file)
+        cmd = 'sonic-installer upgrade-docker -y %s %s' % (self.__container_name, self.__dest_file)
         if self.__cleanup_image:
             cmd += ' --cleanup_image'
             logger.info('firmware: cleanup_image requested.')

--- a/tests/test_DecodeSysEeprom.py
+++ b/tests/test_DecodeSysEeprom.py
@@ -37,33 +37,36 @@ class TestClass(object):
     \endcode
     '''
 
+    DECODE_SYSEEPROM_PATH = '/usr/local/bin/decode-syseeprom'
+    DECODE_SYSEEPROM_BACKUP_PATH = DECODE_SYSEEPROM_PATH + '_org'
+
     def test_missing_utility(self):
         '''!
         Test when we call the constructor function and decode-syseprom utility is missing
         '''
-        shutil.move('/usr/bin/decode-syseeprom', '/usr/bin/decode-syseeprom_org')
+        shutil.move(self.DECODE_SYSEEPROM_PATH, self.DECODE_SYSEEPROM_BACKUP_PATH)
         syseeprom = DecodeSysEeprom()
         assert(syseeprom.get_product_name() != None)
         assert(syseeprom.get_mac_addr() != None)
         assert(syseeprom.get_serial_number() != None)
-        shutil.move('/usr/bin/decode-syseeprom_org', '/usr/bin/decode-syseeprom')
+        shutil.move(self.DECODE_SYSEEPROM_BACKUP_PATH, self.DECODE_SYSEEPROM_PATH)
 
     def test_error_utility(self):
         '''!
         Test when we call the constructor function and decode-syseprom utility is returning an error
         '''
-        shutil.move('/usr/bin/decode-syseeprom', '/usr/bin/decode-syseeprom_org')
-        f = open('/usr/bin/decode-syseeprom', 'w')
+        shutil.move(self.DECODE_SYSEEPROM_PATH, self.DECODE_SYSEEPROM_BACKUP_PATH)
+        f = open(self.DECODE_SYSEEPROM_PATH, 'w')
         f.write('#!/bin/sh\nexit 1\n')
         f.close()
-        st = os.stat('/usr/bin/decode-syseeprom')
-        os.chmod('/usr/bin/decode-syseeprom', st.st_mode | stat.S_IEXEC)
+        st = os.stat(self.DECODE_SYSEEPROM_PATH)
+        os.chmod(self.DECODE_SYSEEPROM_PATH, st.st_mode | stat.S_IEXEC)
         syseeprom = DecodeSysEeprom()
         assert(syseeprom.get_product_name() != None)
         assert(syseeprom.get_mac_addr() != None)
         assert(syseeprom.get_serial_number() != None)
-        os.remove('/usr/bin/decode-syseeprom')
-        shutil.move('/usr/bin/decode-syseeprom_org', '/usr/bin/decode-syseeprom')
+        os.remove(self.DECODE_SYSEEPROM_PATH)
+        shutil.move(self.DECODE_SYSEEPROM_BACKUP_PATH, self.DECODE_SYSEEPROM_PATH)
 
     def test_constructor(self):
         '''!

--- a/tests/test_configdb-json.py
+++ b/tests/test_configdb-json.py
@@ -160,7 +160,7 @@ class TestClass(object):
 
         d = tmpdir.mkdir("valid")
         fh_before = d.join("config-before.json")
-        cmd = '/usr/bin/config save -y ' + str(fh_before)
+        cmd = 'config save -y ' + str(fh_before)
         rc = runCommand(cmd, capture_stdout=False)
         assert(rc == 0)
 
@@ -193,7 +193,7 @@ class TestClass(object):
         configdb_json.main()
 
         fh_after = d.join("config-after.json")
-        cmd = '/usr/bin/config save -y ' + str(fh_after)
+        cmd = 'config save -y ' + str(fh_after)
         rc = runCommand(cmd, capture_stdout=False)
         assert(rc == 0)
 
@@ -202,7 +202,7 @@ class TestClass(object):
         (rc2, cmd_stdout, cmd_stderr) = runCommand(cmd)
 
         # Restore initial configuration
-        cmd = '/usr/bin/config load -y ' + str(fh_before)
+        cmd = 'config load -y ' + str(fh_before)
         rc = runCommand(cmd, capture_stdout=False)
         assert(rc == 0)
 
@@ -215,7 +215,7 @@ class TestClass(object):
 
         d = tmpdir.mkdir("valid")
         fh_before = d.join("config-before.json")
-        cmd = '/usr/bin/config save -y ' + str(fh_before)
+        cmd = 'config save -y ' + str(fh_before)
         rc = runCommand(cmd, capture_stdout=False)
         assert(rc == 0)
 
@@ -248,12 +248,12 @@ class TestClass(object):
         configdb_json.main()
 
         fh_after = d.join("config-after.json")
-        cmd = '/usr/bin/config save -y ' + str(fh_after)
+        cmd = 'config save -y ' + str(fh_after)
         rc = runCommand(cmd, capture_stdout=False)
         assert(rc == 0)
 
         # Restore initial configuration
-        cmd = '/usr/bin/config reload -y ' + str(fh_before)
+        cmd = 'config reload -y ' + str(fh_before)
         rc = runCommand(cmd, capture_stdout=False)
         assert(rc == 0)
-        rc = runCommand('/usr/bin/config save -y', capture_stdout=False)
+        rc = runCommand('config save -y', capture_stdout=False)


### PR DESCRIPTION
Update paths to reflect new sonic-utilities install location. As of PR https://github.com/Azure/sonic-utilities/pull/1122, sonic-utilities is built and installed as a Python Wheel package. As such, the installation directory of the scripts/entrypoints has changed from `/usr/bin/` to `/usr/local/bin`. This patch updates all references to the old location to either reference the new location, or remove the absolute path entirely, where applicable.