### PR TITLE
Setting ipv6 mode default on interfaces for ZTP INBAND

### DIFF
--- a/src/usr/lib/ztp/templates/ztp-config.j2
+++ b/src/usr/lib/ztp/templates/ztp-config.j2
@@ -32,6 +32,15 @@
 
 {%- endfor %}
    },
+{% if ZTP_IPV6 == "true" and ZTP_INBAND == "true" %}
+   "INTERFACE": {
+{%- for port in PORT -%}
+         "{{port}}" : {
+                "ipv6_use_link_local_only": "enable"
+       }{%- if loop.last == False -%},{% endif %}
+{%- endfor %}
+   },
+{% endif %}
    "ZTP" : {
     "mode" : {
         "profile" : "active",


### PR DESCRIPTION
Enable ipv6 enable default on interfaces for ZTP inband

As per HLD - https://github.com/Azure/SONiC/pull/625

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>