### PR TITLE
[sonic-ztp] Add dynamic port breakout(DPB) to ZTP temolate

### DIFF
--- a/src/usr/lib/ztp/templates/ztp-config.j2
+++ b/src/usr/lib/ztp/templates/ztp-config.j2
@@ -1,4 +1,15 @@
 {
+{% if BREAKOUT_CFG %}
+    "BREAKOUT_CFG": {
+{%- for intf in BREAKOUT_CFG -%}
+        "{{intf}}": {
+{% if BREAKOUT_CFG[intf].brkout_mode is defined and BREAKOUT_CFG[intf].brkout_mode != "" %}
+            "brkout_mode": "{{ BREAKOUT_CFG[intf].brkout_mode }}"
+{% endif %}
+        }{%- if loop.last == False -%},{% endif %}
+{%- endfor %}
+    },
+{% endif %}
     "DEVICE_METADATA": { 
       "localhost" : {
        "hwsku" : "{{ DEVICE_METADATA.localhost.hwsku }}",


### PR DESCRIPTION
**- Why I did it**
    To support DPB with the ZTP template.

**-How I did it**
    Generate 'BREAKOUT_CFG' when dynamic port breakout(DPB) is supported on the platform. 
    Revise the ZTP template so that the DPB CLI can be executed when config is generated from the ZTP template.

**-How to verify it**
    Execute DPB cli when the config is generated from ZTP template.