### PR TITLE
Include port default fec configuration to be included in ZTP config

### DIFF
--- a/src/usr/lib/ztp/templates/ztp-config.j2
+++ b/src/usr/lib/ztp/templates/ztp-config.j2
@@ -23,6 +23,9 @@
 {% if PORT[port].valid_speeds is defined and PORT[port].valid_speeds != "" %}
                 "valid_speeds": "{{ PORT[port].valid_speeds }}",
 {% endif %}
+{% if PORT[port].fec is defined and PORT[port].fec != "" %}
+                "fec": "{{ PORT[port].fec }}",
+{% endif %}
 {% if ZTP_INBAND == "true" %}
                 "admin_status": "up"
 {% else %}


### PR DESCRIPTION
When using in-band interfaces for ZTP, it is important that the default
configuration of a port like speed and fec setting is configured correctly
for the port link to come up. This allows ZTP to perform DHCP discovery and
thus provision the device.

The proposed changes allow the ZTP configuration template to include port
fec mode only if it is defined.

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>