### PR TITLE
[sonic-ztp]Fixing build failure after bullseye integration

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,7 @@ Maintainer: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>
 Uploaders: Olivier Singla <olivier.singla@broadcom.com>
 Section: devel
 Priority: optional
-Build-Depends: debhelper (>= 8.0.0),
-               dh-systemd
+Build-Depends: debhelper (>= 8.0.0)
 Standards-Version: 3.9.3
 Homepage: https://github.com/Azure/sonic-ztp
 


### PR DESCRIPTION
Fixes build issue https://github.com/Azure/sonic-buildimage/issues/9524

SONiC build fails with ENABLE_ZTP=y

With sonic upgrade to bullseye, dh-systemd is no longer present in Bullseye, and is not needed for installing systemd service files in a Debian package as mentioned in the [comment](https://github.com/Azure/sonic-buildimage/issues/9524#issuecomment-992977071). Hence removing the dependency
